### PR TITLE
[Sendmail] Support multiple recipients

### DIFF
--- a/lgkemilv3child.groovy
+++ b/lgkemilv3child.groovy
@@ -378,7 +378,7 @@ def parse(String msg) {
         
 	              def sndMsg =[
                       "MAIL FROM: <${From}>"
-                    , "RCPT TO: <${To}>"
+                    , To.tokenize(", ").collect {"RCPT TO: <${it}>"}
 	        		, "DATA"
                     , "From: ${From}"
                     , "To: ${To}"
@@ -393,7 +393,7 @@ def parse(String msg) {
                     , ""
 	        		, "."
 		        	, "quit"
-	            ]  
+	            ].flatten()
                    
                  def res1 = seqSend(sndMsg,500) 
                  state.messageSent = true  


### PR DESCRIPTION
Add support for multiple recipients in "To", separated with commas and/or spaces, e.g. "abc@def.xyz,ghi@jkl.xyz" or "abc@def.xyz, ghi@jkl.xyz". Each recipient is sent to the SMTP server on a separate "RCPT TO" line. This has been tested with both Verizon SMS (@vtext.com) and "normal" (non-SMS) email addresses.